### PR TITLE
Update base_admin.class.php

### DIFF
--- a/inc_php/framework/base_admin.class.php
+++ b/inc_php/framework/base_admin.class.php
@@ -20,7 +20,7 @@
 		private static $tempVars = array();
 		private static $startupError = "";
 		private static $menuRole = self::ROLE_ADMIN;
-		private static $arrMetaBoxes = "";		//option boxes that will be added to post
+		private static $arrMetaBoxes = array();		//option boxes that will be added to post
 		
 		private static $allowed_views = array('master-view', 'system/validation', 'system/video_dialog', 'system/update_dialog', 'system/general_settings_dialog', 'sliders', 'slider', 'slider_template', 'slides', 'slide', 'navigation-editor', 'slide-editor', 'slide-overview', 'slide-editor', 'slider-overview', 'themepunch-google-fonts');
 		


### PR DESCRIPTION
On PHP 7.3 + there is a bug with with this variable: 

`Fatal error: Uncaught Error: [] operator not supported for strings in /wp/wp-content/plugins/revslider/includes/framework/base-admin.class.php:71`

On line 73 you are trying to add a new array element for a string:

`self::$arrMetaBoxes[] = $box;	`